### PR TITLE
upgrade ruby and fix webrick issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.5
+FROM ruby:2.6.6-alpine
 
 LABEL maintainer="ttksm <ttksm.git@gmail.com>"
 
@@ -6,8 +6,7 @@ USER root
 
 RUN mkdir /app \
     && gem update --system \
-    && gem uninstall bundler \
-    && gem install bundler -v 2.1.4
+    && gem install bundler
 
 WORKDIR /app
 COPY Gemfile* config.ru ./

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'geminabox', '~> 1.2.0'
+gem 'webrick', '~> 1.7.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,12 +27,14 @@ GEM
       rack-protection (= 2.0.8.1)
       tilt (~> 2.0)
     tilt (2.0.10)
+    webrick (1.7.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   geminabox (~> 1.2.0)
+  webrick (~> 1.7.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 [Geminabox](https://github.com/geminabox/geminabox) lets you host your own gems, and push new gems to it just like with rubygems.org.
-This docker image include Geminabox on runtime of the official [ruby:2.6.5](https://hub.docker.com/_/ruby).
+This docker image include Geminabox on runtime of the official [ruby:2.6.6-alpine](https://hub.docker.com/_/ruby).
 
 ## Usage
 


### PR DESCRIPTION
Thank you for the Docker image.

I found a security issue with Webrick and change the base OS.
It will decrease image size.

https://www.ruby-lang.org/en/news/2020/09/29/http-request-smuggling-cve-2020-25613/

<img width="1156" alt="image" src="https://user-images.githubusercontent.com/579103/102323981-1c1a2400-3f79-11eb-9d17-f52a000f493b.png">
